### PR TITLE
add pull request pipeline workflow for order and catalog services

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,7 +51,7 @@ jobs:
           
       - name: Upload test results
         if: always()  # Run even if previous steps fail
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: |
@@ -60,7 +60,7 @@ jobs:
             
       - name: Upload JaCoCo coverage report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jacoco-report
           path: |

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,68 @@
+name: Pull Request Pipeline
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  detect-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      
+      - name: Detect changes in services
+        id: detect_changes
+        run: |
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '^backend/novalume-order-service/'; then
+            echo "order_service_changed=true" >> $GITHUB_ENV
+          else
+            echo "order_service_changed=false" >> $GITHUB_ENV
+          fi
+          
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '^backend/novalume-catalog-service/'; then
+            echo "catalog_service_changed=true" >> $GITHUB_ENV
+          else
+            echo "catalog_service_changed=false" >> $GITHUB_ENV
+          fi
+
+      - name: Test and build novalume-order-service
+        if: ${{ env.order_service_changed == 'true' }}
+        run: |
+          cd backend/novalume-order-service
+          mvn verify
+
+      - name: Test and build novalume-catalog-service
+        if: ${{ env.catalog_service_changed == 'true' }}
+        run: |
+          cd backend/novalume-catalog-service
+          mvn verify
+          
+      - name: Upload test results
+        if: always()  # Run even if previous steps fail
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: |
+            backend/novalume-order-service/target/surefire-reports/
+            backend/novalume-catalog-service/target/surefire-reports/
+            
+      - name: Upload JaCoCo coverage report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco-report
+          path: |
+            backend/novalume-order-service/target/site/jacoco/
+            backend/novalume-catalog-service/target/site/jacoco/

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -36,6 +36,12 @@ jobs:
           else
             echo "catalog_service_changed=false" >> $GITHUB_ENV
           fi
+          
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '^frontend/'; then
+            echo "frontend_changed=true" >> $GITHUB_ENV
+          else
+            echo "frontend_changed=false" >> $GITHUB_ENV
+          fi
 
       - name: Test and build novalume-order-service
         if: ${{ env.order_service_changed == 'true' }}
@@ -48,6 +54,52 @@ jobs:
         run: |
           cd backend/novalume-catalog-service
           mvn verify
+          
+      - name: Setup Node.js
+        if: ${{ env.frontend_changed == 'true' }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+          
+      - name: Install Angular dependencies
+        if: ${{ env.frontend_changed == 'true' }}
+        run: |
+          cd frontend
+          npm ci
+          
+      - name: Lint frontend
+        if: ${{ env.frontend_changed == 'true' }}
+        run: |
+          cd frontend
+          npm run lint
+          
+      - name: Test frontend
+        if: ${{ env.frontend_changed == 'true' }}
+        run: |
+          cd frontend
+          npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+          
+      - name: Build frontend
+        if: ${{ env.frontend_changed == 'true' }}
+        run: |
+          cd frontend
+          npm run build -- --configuration production
+          
+      - name: Upload frontend test results
+        if: ${{ env.frontend_changed == 'true' && always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-test-results
+          path: frontend/coverage
+          
+      - name: Upload frontend build
+        if: ${{ env.frontend_changed == 'true' && success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/dist
           
       - name: Upload test results
         if: always()  # Run even if previous steps fail

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -102,7 +102,7 @@ jobs:
           path: frontend/dist
           
       - name: Upload test results
-        if: always()  # Run even if previous steps fail
+        if: ${{ env.order_service_changed == 'true' || env.catalog_service_changed == 'true' && success() }}
         uses: actions/upload-artifact@v4
         with:
           name: test-results
@@ -111,7 +111,7 @@ jobs:
             backend/novalume-catalog-service/target/surefire-reports/
             
       - name: Upload JaCoCo coverage report
-        if: always()
+        if: ${{ env.order_service_changed == 'true' || env.catalog_service_changed == 'true' && success() }}
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-report


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the testing and building of services in the repository. The workflow is designed to detect changes in specific services and conditionally execute relevant steps, improving efficiency and ensuring targeted validation.

### New GitHub Actions Workflow:

* `.github/workflows/pull-request.yaml`: Added a workflow named "Pull Request Pipeline" that triggers on pull requests to the `develop` branch. It includes:
  - A step to detect changes in `novalume-order-service` and `novalume-catalog-service` directories and set environment variables accordingly.
  - Conditional steps to test and build the `novalume-order-service` and `novalume-catalog-service` if changes are detected.
  - Steps to upload test results and JaCoCo coverage reports as artifacts, ensuring visibility into test outcomes and code coverage.